### PR TITLE
Fix micro symbol rendering for fiber and diameter specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@
                             <h4><span class="mono">V25-850M</span></h4>
                             <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">28 GBPS (NRZ)</span></div>
                             <div class="spec"><span class="spec-label">Wavelength</span><span class="mono">850 NM</span></div>
-                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">50/125 µM</span></div>
+                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">50/125 µM</span></div>
                         </div>
                     </div>
                     <div class="product-card" data-datasheet="https://v-i-systems.com/wp-content/uploads/2022/01/VIS-Datasheet-V50-850M-module.pdf">
@@ -478,7 +478,7 @@
                             <h4><span class="mono">V50-850M</span></h4>
                             <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">56 GBPS (PAM-4)</span></div>
                             <div class="spec"><span class="spec-label">Wavelength</span><span class="mono">850 NM</span></div>
-                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">50/125 µM</span></div>
+                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">50/125 µM</span></div>
                         </div>
                     </div>
                     <div class="product-card" data-datasheet="https://v-i-systems.com/wp-content/uploads/2022/01/VIS-Datasheet-VM100-850M-module.pdf">
@@ -487,7 +487,7 @@
                             <h4><span class="mono">VM100-850M</span></h4>
                             <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">112 GBPS (PAM-4)</span></div>
                             <div class="spec"><span class="spec-label">Wavelength</span><span class="mono">850 NM</span></div>
-                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">50/125 µM</span></div>
+                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">50/125 µM</span></div>
                         </div>
                     </div>
                     <div class="product-card" data-datasheet="https://v-i-systems.com/wp-content/uploads/2022/10/VI-Systems-GmbH-T56-850-Transmitter-subassembly-for-up-to-56-Gbits-NRZ-datasheet.pdf">
@@ -496,7 +496,7 @@
                             <h4><span class="mono">T56-850</span></h4>
                             <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">56 GBPS (NRZ)</span></div>
                             <div class="spec"><span class="spec-label">Wavelength</span><span class="mono">850 NM</span></div>
-                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">50/125 µM</span></div>
+                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">50/125 µM</span></div>
                         </div>
                     </div>
 <!-- V25-1550M (new single-mode transmitter module) -->
@@ -506,7 +506,7 @@
     <h4><span class="mono">V25-1550M</span></h4>
     <div class="spec"><span class="spec-label">Wavelength</span><span class="mono">1550 NM</span></div>
     <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">25 GBPS (NRZ)</span></div>
-    <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">9/125 µM</span></div>
+    <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">9/125 µM</span></div>
   </div>
 </div>
                 </div>
@@ -562,7 +562,7 @@
     <h4><span class="mono">R56-850</span></h4>
     <div class="spec"><span class="spec-label">Input Wavelength</span><span class="mono">700–870 NM</span></div>
     <div class="spec"><span class="spec-label">Data Rate (NRZ)</span><span class="mono">56 GBPS</span></div>
-    <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">50/125 µM</span></div>
+    <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">50/125 µM</span></div>
   </div>
 </div>
                     <div class="product-card" data-datasheet="https://v-i-systems.com/wp-content/uploads/2022/06/VIS-Datasheet-D30-850M.pdf">
@@ -571,7 +571,7 @@
                             <h4><span class="mono">D30-850M</span></h4>
                             <div class="spec"><span class="spec-label">3 dB Bandwidth</span><span class="mono">&gt; 30 <span class="no-caps">GHz</span></span></div>
                             <div class="spec"><span class="spec-label">Wavelength</span><span class="mono">840-1650 NM</span></div>
-                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono">50/125 µM</span></div>
+                            <div class="spec"><span class="spec-label">Fiber Type</span><span class="mono no-caps">50/125 µM</span></div>
                         </div>
                     </div>
 <!-- D60M FC (new photodetector module) -->
@@ -1002,7 +1002,7 @@
       <div class="product-details">
         <h4><span class="mono">D40 SWDM</span></h4>
         <div class="spec"><span class="spec-label">Contact Type</span><span class="mono">GSG</span></div>
-        <div class="spec"><span class="spec-label">Diameter</span><span class="mono">20 µm</span></div>
+        <div class="spec"><span class="spec-label">Diameter</span><span class="mono no-caps">20 µM</span></div>
         <div class="spec"><span class="spec-label">Bandwidth</span><span class="mono">~40 <span class="no-caps">GHz</span></span></div>
       </div>
     </div>
@@ -1012,7 +1012,7 @@
       <div class="product-details">
         <h4><span class="mono">D35 SWDM</span></h4>
         <div class="spec"><span class="spec-label">Contact Type</span><span class="mono">GSG</span></div>
-        <div class="spec"><span class="spec-label">Diameter</span><span class="mono">25 µm</span></div>
+        <div class="spec"><span class="spec-label">Diameter</span><span class="mono no-caps">25 µM</span></div>
         <div class="spec"><span class="spec-label">Bandwidth</span><span class="mono">~35 <span class="no-caps">GHz</span></span></div>
       </div>
     </div>
@@ -1022,7 +1022,7 @@
       <div class="product-details">
         <h4><span class="mono">D30 SWDM</span></h4>
         <div class="spec"><span class="spec-label">Contact Type</span><span class="mono">GSG</span></div>
-        <div class="spec"><span class="spec-label">Diameter</span><span class="mono">~23 µm</span></div>
+        <div class="spec"><span class="spec-label">Diameter</span><span class="mono no-caps">~23 µM</span></div>
         <div class="spec"><span class="spec-label">Bandwidth</span><span class="mono">~30 <span class="no-caps">GHz</span></span></div>
       </div>
     </div>
@@ -1032,7 +1032,7 @@
       <div class="product-details">
         <h4><span class="mono">D70 SWDM</span></h4>
         <div class="spec"><span class="spec-label">Contact Type</span><span class="mono">GSG</span></div>
-        <div class="spec"><span class="spec-label">Diameter</span><span class="mono">~25 µm</span></div>
+        <div class="spec"><span class="spec-label">Diameter</span><span class="mono no-caps">~25 µM</span></div>
         <div class="spec"><span class="spec-label">Bandwidth</span><span class="mono">~70 <span class="no-caps">GHz</span></span></div>
       </div>
     </div>
@@ -1042,7 +1042,7 @@
       <div class="product-details">
         <h4><span class="mono">D400G</span></h4>
         <div class="spec"><span class="spec-label">Contact Type</span><span class="mono">GSG</span></div>
-        <div class="spec"><span class="spec-label">Diameter</span><span class="mono">~16 µm</span></div>
+        <div class="spec"><span class="spec-label">Diameter</span><span class="mono no-caps">~16 µM</span></div>
         <div class="spec"><span class="spec-label">Bandwidth</span><span class="mono">~60 <span class="no-caps">GHz</span> (25Ω)</span></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure fiber type specifications on transmitter and receiver pages retain the lowercase micro symbol by opting out of the global uppercase transform
- update diameter specifications on page 13 to display the correct µM units while preventing unwanted capitalization

## Testing
- `npm run export-pdf` *(fails: puppeteer could not launch Chrome because libatk-1.0.so.0 is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11e6028c083249093963b3535bccf