### PR TITLE
Replace catalog placeholders with new imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,7 @@
                     <div class="content-right">
                         <figure class="catalog-image">
                             <img src="media/integrationchip.png" alt="Integrated VCSEL driver with VCSEL chip">
+                            <figcaption class="catalog-caption">single channel 56G NRZ VCSEL driver with VCSEL<br>chip</figcaption>
                         </figure>
                     </div>
                 </div>
@@ -293,9 +294,6 @@
 
                         <p>EMISSION ANALYSIS: NEARFIELD AND FARFIELD ANALYSIS FOR EMITTING DIAMETER, MODE CHARACTERISTICS, POLARIZATION AND ANGULAR POWER DISTRIBUTION.</p>
 
-                        <figure class="catalog-image catalog-image--lab">
-                            <img src="media/labphoto.png" alt="Semi-automatic wafer prober and alignment camera">
-                        </figure>
                     </div>
 
                     <div class="column-right">
@@ -313,6 +311,10 @@
 
                     </div>
                 </div>
+
+                <figure class="catalog-image catalog-image--lab">
+                    <img src="media/labphoto.png" alt="Semi-automatic wafer prober and alignment camera">
+                </figure>
             </div>
             <footer class="page-footer">
                 <div class="footer-left">
@@ -384,9 +386,11 @@
                         <div class="content-right">
                             <figure class="catalog-image">
                                 <img src="media/stereomicroscope.png" alt="Stereo microscope with temperature chuck">
+                                <figcaption class="catalog-caption">stereo microscope with temperature chuck</figcaption>
                             </figure>
                             <figure class="catalog-image">
                                 <img src="media/opticalmicroscope.png" alt="High-resolution optical microscope">
+                                <figcaption class="catalog-caption">high resolution optical microscope</figcaption>
                             </figure>
                         </div>
                     </div>
@@ -405,6 +409,7 @@
                         <div class="content-right">
                             <figure class="catalog-image">
                                 <img src="media/thermal.png" alt="Thermal distribution analysis graphic">
+                                <figcaption class="catalog-caption">Thermal distribution in a VCSEL</figcaption>
                             </figure>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -223,12 +223,9 @@
                     </div>
 
                     <div class="content-right">
-                        <div class="image-placeholder">
-                            <div class="placeholder-text">INTEGRATED VCSEL DRIVER WITH VCSEL CHIP PHOTO</div>
-                        </div>
-                        <div class="image-placeholder">
-                            <div class="placeholder-text">CONCEPTUAL GRAPHIC: ICs + OPTICAL COMPONENTS INTEGRATION</div>
-                        </div>
+                        <figure class="catalog-image">
+                            <img src="media/integrationchip.png" alt="Integrated VCSEL driver with VCSEL chip">
+                        </figure>
                     </div>
                 </div>
             </div>
@@ -296,9 +293,9 @@
 
                         <p>EMISSION ANALYSIS: NEARFIELD AND FARFIELD ANALYSIS FOR EMITTING DIAMETER, MODE CHARACTERISTICS, POLARIZATION AND ANGULAR POWER DISTRIBUTION.</p>
 
-                        <div class="image-placeholder">
-                            <div class="placeholder-text">SEMI-AUTOMATIC WAFER PROBER AND ALIGNMENT CAMERA PHOTO</div>
-                        </div>
+                        <figure class="catalog-image catalog-image--lab">
+                            <img src="media/labphoto.png" alt="Semi-automatic wafer prober and alignment camera">
+                        </figure>
                     </div>
 
                     <div class="column-right">
@@ -314,9 +311,6 @@
                             <li>PHOTODETECTOR MODULES UP TO <span class="mono">112 GBIT/S</span> AT <span class="mono">850 NM</span></li>
                         </ul>
 
-                        <div class="image-placeholder">
-                            <div class="placeholder-text">HIGH-FREQUENCY TEST LABORATORY SETUP PHOTO</div>
-                        </div>
                     </div>
                 </div>
             </div>
@@ -388,15 +382,12 @@
                         </div>
 
                         <div class="content-right">
-                            <div class="image-placeholder small">
-                                <div class="placeholder-text">STEREO MICROSCOPE WITH TEMPERATURE CHUCK</div>
-                            </div>
-                            <div class="image-placeholder small">
-                                <div class="placeholder-text">HIGH-RESOLUTION OPTICAL MICROSCOPE</div>
-                            </div>
-                            <div class="image-placeholder small">
-                                <div class="placeholder-text">TEM ANALYSIS PHOTO</div>
-                            </div>
+                            <figure class="catalog-image">
+                                <img src="media/stereomicroscope.png" alt="Stereo microscope with temperature chuck">
+                            </figure>
+                            <figure class="catalog-image">
+                                <img src="media/opticalmicroscope.png" alt="High-resolution optical microscope">
+                            </figure>
                         </div>
                     </div>
                 </div>
@@ -412,9 +403,9 @@
                         </div>
 
                         <div class="content-right">
-                            <div class="image-placeholder">
-                                <div class="placeholder-text">THERMAL DISTRIBUTION GRAPHIC</div>
-                            </div>
+                            <figure class="catalog-image">
+                                <img src="media/thermal.png" alt="Thermal distribution analysis graphic">
+                            </figure>
                         </div>
                     </div>
                 </div>

--- a/print.css
+++ b/print.css
@@ -208,6 +208,8 @@ body {
 .catalog-image {
     background-color: #d0dce2 !important;
     border-radius: 4px !important;
+    display: flex !important;
+    flex-direction: column !important;
     margin: 0 !important;
     overflow: hidden !important;
     width: 100% !important;
@@ -219,11 +221,23 @@ body {
     height: auto !important;
 }
 
+.catalog-caption {
+    margin: 0 !important;
+    padding: 0.5rem 0.75rem !important;
+    font-size: 0.7rem !important;
+    line-height: 1.3 !important;
+    color: #273638 !important;
+    background-color: rgba(255, 255, 255, 0.85) !important;
+    border-top: 1px solid #c2d4dd !important;
+}
+
 .catalog-image--lab {
-    aspect-ratio: 1018 / 464 !important;
+    margin-top: 1.5rem !important;
+    height: 240px !important;
 }
 
 .catalog-image--lab img {
+    width: 100% !important;
     height: 100% !important;
     object-fit: cover !important;
 }

--- a/print.css
+++ b/print.css
@@ -227,12 +227,12 @@ body {
     font-size: 0.7rem !important;
     line-height: 1.3 !important;
     color: #273638 !important;
-    background-color: rgba(255, 255, 255, 0.85) !important;
-    border-top: 1px solid #c2d4dd !important;
+    background-color: #d0dce2 !important;
+    border-top: 1px solid #b0c4de !important;
 }
 
 .catalog-image--lab {
-    margin-top: 1.5rem !important;
+    margin-top: 0.75rem !important;
     height: 240px !important;
 }
 

--- a/print.css
+++ b/print.css
@@ -206,7 +206,7 @@ body {
 }
 
 .catalog-image {
-    background-color: #d0dce2 !important;
+    background-color: #c4e3e8 !important;
     border-radius: 4px !important;
     display: flex !important;
     flex-direction: column !important;
@@ -227,12 +227,12 @@ body {
     font-size: 0.7rem !important;
     line-height: 1.3 !important;
     color: #273638 !important;
-    background-color: #d0dce2 !important;
+    background-color: #c4e3e8 !important;
     border-top: 1px solid #b0c4de !important;
 }
 
 .catalog-image--lab {
-    margin-top: 0.75rem !important;
+    margin-top: 0.3rem !important;
     height: 240px !important;
 }
 

--- a/print.css
+++ b/print.css
@@ -205,6 +205,29 @@ body {
     opacity: 1 !important;
 }
 
+.catalog-image {
+    background-color: #d0dce2 !important;
+    border-radius: 4px !important;
+    margin: 0 !important;
+    overflow: hidden !important;
+    width: 100% !important;
+}
+
+.catalog-image img {
+    display: block !important;
+    width: 100% !important;
+    height: auto !important;
+}
+
+.catalog-image--lab {
+    aspect-ratio: 1018 / 464 !important;
+}
+
+.catalog-image--lab img {
+    height: 100% !important;
+    object-fit: cover !important;
+}
+
 /* ---
 FORCE BUTTON STYLES FOR PDF EXPORT
 --- */

--- a/style.css
+++ b/style.css
@@ -624,7 +624,8 @@ p {
 .catalog-image {
     background-color: #d0dce2;
     border-radius: 4px;
-    display: block;
+    display: flex;
+    flex-direction: column;
     margin: 0;
     overflow: hidden;
     width: 100%;
@@ -636,11 +637,23 @@ p {
     height: auto;
 }
 
+.catalog-caption {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    color: #273638;
+    background-color: rgba(255, 255, 255, 0.85);
+    border-top: 1px solid #c2d4dd;
+}
+
 .catalog-image--lab {
-    aspect-ratio: 1018 / 464;
+    margin-top: 2rem;
+    height: clamp(240px, 28vw, 320px);
 }
 
 .catalog-image--lab img {
+    width: 100%;
     height: 100%;
     object-fit: cover;
 }

--- a/style.css
+++ b/style.css
@@ -643,12 +643,12 @@ p {
     font-size: 0.75rem;
     line-height: 1.3;
     color: #273638;
-    background-color: rgba(255, 255, 255, 0.85);
-    border-top: 1px solid #c2d4dd;
+    background-color: #d0dce2;
+    border-top: 1px solid #b0c4de;
 }
 
 .catalog-image--lab {
-    margin-top: 2rem;
+    margin-top: 1rem;
     height: clamp(240px, 28vw, 320px);
 }
 
@@ -666,8 +666,13 @@ p {
 }
 
 /* --- Inspection and Modelling Sections --- */
-.inspection-section, .modelling-section {
+.inspection-section {
+    margin-bottom: 1.5rem;
+}
+
+.modelling-section {
     margin-bottom: 2rem;
+    margin-top: 0.75rem;
 }
 
 .inspection-section h3, .modelling-section h3 {

--- a/style.css
+++ b/style.css
@@ -621,6 +621,30 @@ p {
     padding: 1rem;
 }
 
+.catalog-image {
+    background-color: #d0dce2;
+    border-radius: 4px;
+    display: block;
+    margin: 0;
+    overflow: hidden;
+    width: 100%;
+}
+
+.catalog-image img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.catalog-image--lab {
+    aspect-ratio: 1018 / 464;
+}
+
+.catalog-image--lab img {
+    height: 100%;
+    object-fit: cover;
+}
+
 .placeholder-text {
     font-size: 0.8rem;
     color: #666;

--- a/style.css
+++ b/style.css
@@ -622,7 +622,7 @@ p {
 }
 
 .catalog-image {
-    background-color: #d0dce2;
+    background-color: #c4e3e8;
     border-radius: 4px;
     display: flex;
     flex-direction: column;
@@ -643,12 +643,12 @@ p {
     font-size: 0.75rem;
     line-height: 1.3;
     color: #273638;
-    background-color: #d0dce2;
+    background-color: #c4e3e8;
     border-top: 1px solid #b0c4de;
 }
 
 .catalog-image--lab {
-    margin-top: 1rem;
+    margin-top: 0.25rem;
     height: clamp(240px, 28vw, 320px);
 }
 
@@ -672,7 +672,7 @@ p {
 
 .modelling-section {
     margin-bottom: 2rem;
-    margin-top: 0.75rem;
+    margin-top: 0.3rem;
 }
 
 .inspection-section h3, .modelling-section h3 {


### PR DESCRIPTION
## Summary
- swap page 3's integrated solutions placeholder for the new integrationchip artwork and remove the conceptual graphic block
- update wafer mapping imagery to show the new labphoto asset and drop the unused high-frequency setup placeholder
- populate inspection and modelling sections with stereomicroscope, opticalmicroscope, and thermal graphics while clearing the old placeholders

## Testing
- not run (static asset update)


------
https://chatgpt.com/codex/tasks/task_e_68d13a6e960483249d7057474289c1dd