### PR TITLE
Update product catalog text

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
             <div class="page-content">
                 <h2><span class="numbered-header">01.</span> WELCOME TO VI SYSTEMS</h2>
                 <p>VI SYSTEMS (VIS) DEVELOPS AND MANUFACTURES CUTTING-EDGE OPTOELECTRONIC COMPONENTS FOR COMMUNICATION, CONSUMER, AND AUTOMOTIVE APPLICATIONS. LOCATED IN THE HEART OF BERLIN, WE ARE A FABLESS COMPANY SPECIALIZING IN ULTRA-FAST SOLUTIONS FOR OPTICAL INTERCONNECTS AND SENSORS.</p>
-                <p>OUR PORTFOLIO INCLUDES VERTICAL CAVITY SURFACE-EMITTING LASERS (VCSELS) AND PIN PHOTODIODES DELIVERING SPEEDS UP TO <span class="mono">224 GBPS</span> PER CHANNEL, ALONGSIDE DRIVER AND AMPLIFIER ICS OPERATING UP TO <span class="mono">56 GBPS</span>. OUR LATEST GENERATION COMPONENTS ENABLE ENERGY-EFFICIENT <span class="mono">400 GBPS</span> PAM-4 TRANSMISSION USING SHORT WAVE DIVISION MULTIPLEXING (SWDM).</p>
+                <p>OUR PORTFOLIO INCLUDES VERTICAL CAVITY SURFACE-EMITTING LASERS (VCSELS) UP TO 246 Gb/s AND PIN PHOTODIODES UP TO 400Gb/s PER CHANNEL, ALONGSIDE DRIVER AND AMPLIFIER ICS OPERATING UP TO 80Gbaud. OUR COMPONENTS ENABLE ENERGY-EFFICIENT 400 Gb/s PAM-4 TRANSMISSION PER 4 WAVELENGTH CHANNELS USING SHORT WAVE DIVISION MULTIPLEXING (SWDM) OVER 300m OF MULTIMODE FIBER. 100Gb/s SINGLE MODE FIBER DATA TRANSMISSION OVER KM-LONG DISTANCES IS POSSIBLE.</p>
             </div>
             <footer class="page-footer">
                 <div class="footer-left">
@@ -225,7 +225,7 @@
                     <div class="content-right">
                         <figure class="catalog-image">
                             <img src="media/integrationchip.png" alt="Integrated VCSEL driver with VCSEL chip">
-                            <figcaption class="catalog-caption">single channel 56G NRZ VCSEL driver with VCSEL<br>chip</figcaption>
+                            <figcaption class="catalog-caption">single channel NRZ VCSEL driver with VCSEL<br>chip</figcaption>
                         </figure>
                     </div>
                 </div>
@@ -631,7 +631,7 @@
                         <div class="product-image-placeholder"></div>
                         <div class="product-details">
                             <h4><span class="mono">A56-230C</span></h4>
-                            <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">up to 100 GBPS</span></div>
+                            <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">UP TO 100 Gbaud</span></div>
                             <div class="spec"><span class="spec-label">Supply Voltage</span><span class="mono">3.3 V</span></div>
                             <div class="spec"><span class="spec-label">Power Dissipation</span><span class="mono">200 mW</span></div>
                         </div>
@@ -640,7 +640,7 @@
                         <div class="product-image-placeholder"></div>
                         <div class="product-details">
                             <h4><span class="mono">A56-105C</span></h4>
-                            <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">UP TO 56 GBPS</span></div>
+                            <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">UP TO 100 Gbaud</span></div>
                             <div class="spec"><span class="spec-label">Supply Voltage</span><span class="mono">3.3 V</span></div>
                             <div class="spec"><span class="spec-label">Power Dissipation</span><span class="mono">105 MW</span></div>
                         </div>
@@ -650,7 +650,7 @@
   <div class="product-image-placeholder"></div>
   <div class="product-details">
     <h4><span class="mono">T56-250C</span></h4>
-    <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">up to 56 GBPS (NRZ)</span></div>
+    <div class="spec"><span class="spec-label">Data Rate</span><span class="mono">UP TO 100 Gbaud</span></div>
     <div class="spec"><span class="spec-label">Differential Gain</span><span class="mono">3.0 kΩ</span></div>
     <div class="spec"><span class="spec-label">Power Dissipation</span><span class="mono">150 mW</span></div>
   </div>


### PR DESCRIPTION
Based on user feedback, this commit makes the following changes to the product catalog (index.html):

- Page 2: Replaces the second paragraph with new information about VCSELs, photodiodes, and transmission capabilities.
- Page 4: Removes "56G" from an image caption to make it more general.
- Page 9: Standardizes the "Data Rate" for all IC products to "UP TO 100 Gbaud".